### PR TITLE
Using callbacks also in run method

### DIFF
--- a/utils/problem.js
+++ b/utils/problem.js
@@ -22,10 +22,13 @@ module.exports = dirname => ({
     });
   },
 
-  run: function (args) {
+  run: function (args, done) {
     execute(args, (err, stdio, stdout, stderr, code) => {
-      if (err) { throw err; }
+      if (err) {
+        done(err, false);
+      }
       console.log(stdio.toString());
+      done()
     });
   }
 });


### PR DESCRIPTION
The run method also requires a callback. Without it workshopper-adventure will close the parent process.
