### PR TITLE
Added solutionPath to be printed as solution as well.

### DIFF
--- a/utils/problem.js
+++ b/utils/problem.js
@@ -15,10 +15,12 @@ module.exports = (dirname, getArgs) => {
 
     this.problem =
       { file: path.join(dirname, `problem.${lang}.md`) };
-    this.solution =
-      { file: path.join(dirname, `solution`, `solution.${lang}.md`) };
     this.solutionPath =
       path.resolve(dirname, `solution`, `solution.bash`);
+    this.solution = [
+      { file: this.solutionPath },
+      { file: path.join(dirname, `solution`, `solution.${lang}.md`) }
+    ];
     this.troubleshooting =
       path.join(__dirname, '..', 'i18n', 'troubleshooting', `${lang}.md`)
   };


### PR DESCRIPTION
In order to show the solution files they need to be added to the `solution` print output. This PR adds the solution files to the output and closes #39 